### PR TITLE
Add "QuickplayPremium" update

### DIFF
--- a/installer/addons.json
+++ b/installer/addons.json
@@ -54,6 +54,17 @@
       "url": "https://github.com/asbyth/Quickplay2.0/releases/download/Hyperium-2.0.4/Quickplay-Hyperium-2.0.4-asbyth.jar",
       "depends": [],
       "enabled": true
+    },
+    {
+      "name": "Quickplay Premium",
+      "description": "Paid addition to Quickplay. More info at https://bugg.co/quickplay/premium/",
+      "version": "1.0.4",
+      "author": "bugfroggy",
+      "verified": true,
+      "sha256": "6749992804880db4139417b8b011435cec041b7afc076ebf5c86d1330acf103e",
+      "url": "https://bugg.co/quickplay/jars/Quickplay%20Premium%20Hyperium-1.0.4.jar",
+      "depends":["Quickplay"],
+      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
Hypixel added breaking changes so I had to push an update, despite my vexation. Originally I was planning on taking classes this summer, however due to the virus, this will not be happening. Once I finish and catch up on my other projects, I hope to further work on Quickplay and fix some of the more critical bugs, which will mean I can push an "official" update to the main jar as well. 

Due to limitations in my current update system, I cannot do it currently without updating for all versions of the game, and it doesn't make sense to do this when there's no content to include in the update.